### PR TITLE
Add default trait implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,3 +93,12 @@ where
         self.0 == other.0
     }
 }
+
+impl<T> Default for Json<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Json(T::default())
+    }
+}


### PR DESCRIPTION
This small PR implements the `Default` trait for `Json`.
It's helpful in creating a default payload to insert in a table (mainly in tests).