### PR TITLE
remove default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["database", "encoding"]
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = ">=0.8.0, <2.0" }
-diesel = { version = "2.0", features = ["postgres", "serde_json"] }
+diesel = { version = "2.0", features = ["postgres", "serde_json"], default-features = false }
 
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
 //! Implements utility type for JSON, JSONB field handling in diesel
 
-#[macro_use]
 extern crate diesel;
 #[macro_use]
 extern crate serde;
 
+use diesel::deserialize::FromSqlRow;
+use diesel::expression::AsExpression;
 use diesel::pg::{Pg, PgValue};
 use diesel::sql_types;
 use diesel::{deserialize::FromSql, serialize::ToSql};


### PR DESCRIPTION
Hello! 

[By default diesel enables two feature flags, `32-column-tables` and `32-column-tables`](https://docs.rs/diesel/2.1.0/diesel/#crate-feature-flags). Disabling them improves compile times, but users of this library cannot do that since this library enables them.

This PR fixes that. Explicit imports were added, since the [implicit imports are deprecated](https://github.com/diesel-rs/diesel/blob/575e63b8e1de1409ab5e0ffbb0586db9df841dfc/diesel/src/lib.rs#L310).


